### PR TITLE
Reduce docker image size

### DIFF
--- a/base-api/Dockerfile
+++ b/base-api/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM microsoft/dotnet:2.2-sdk
+FROM microsoft/dotnet:2.2-sdk as builder
 
 WORKDIR /app
 
@@ -11,6 +10,10 @@ RUN dotnet restore
 COPY . ./
 RUN dotnet publish -c Release -o out
 
+# Use a smaller image
+FROM microsoft/dotnet:2.2.0-aspnetcore-runtime-alpine
+
+# Set env variables required for new relic
 ENV CORECLR_ENABLE_PROFILING=1 \
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
 CORECLR_NEWRELIC_HOME=./out/newrelic \
@@ -18,6 +21,9 @@ CORECLR_PROFILER_PATH=./out/newrelic/libNewRelicProfiler.so \
 NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}" \
 NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME}"
 
-EXPOSE ${PORT:-3000}
+# Copy over the compiled application from the build image
+WORKDIR /app
+COPY --from=builder /app/out .
 
-CMD ASPNETCORE_URLS=http://+:${PORT:-3000} dotnet ./out/base-api.dll
+EXPOSE ${PORT:-3000}
+CMD ASPNETCORE_URLS=http://+:${PORT:-3000} dotnet ./base-api.dll


### PR DESCRIPTION
The dockerfile now uses two different images for the building process: the regular dotnet SDK that we use for compiling the project and the lightweight dotnet runtime apine image for running the program and hold the final image.
The use of the runtime alpine image does bring down the final image size from 728.42mb to 195mb.