### PR TITLE
A fix so that failing tests on the pipeline would get detected.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           command: docker-compose build base-api-test
       - run:
           name: Run tests
-          command: docker-compose up base-api-test
+          command: docker-compose run base-api-test
 
   deploy-to-development:
     docker:


### PR DESCRIPTION
# What:
- A keyword change to fix the CI pipeline issue where even if the tests fail, the build will be shown as success. Snip of the issue:

![image](https://user-images.githubusercontent.com/43747286/69236277-16da8200-0b8b-11ea-8141-d4c31f5e2109.png)This is how the [build](https://circleci.com/gh/LBHackney-IT/property-api/232?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) of **most recent** commit on [property api](https://github.com/LBHackney-IT/property-api/commits/master) _(it follows this template)_ looks like:

# Why:
- So that we would know when something is broken.
- Changing it here so that we wouldn't need to do this for every API that we build off this template.

# Notes:
- According to [docker documentation](https://docs.docker.com/compose/faq/#whats-the-difference-between-up-run-and-start), we should use "docker-compose run", rather than "docker-compose up" to run tests.
