### PR TITLE
Feature - Powershell Renaming Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,29 @@ Base API is a boilerplate code for being reused for new APIs for LBH
 1. Install [Docker][docker-download].
 2. Install [AWS CLI][AWS-CLI].
 3. Clone this repository.
-4. Open it in your IDE.
+4. Rename the initial template.
+5. Open it in your IDE.
+
+### Renaming
+
+The renaming of `base-api` into `SomethingElseApi` can be done by running a Renamer powershell script. To do so:
+1. Open the powershell and navigate to this directory's root.
+2. And run the script using the following command:
+```
+.\Renamer.ps1 -apiName My_Api
+```
+
+If your script execution policiy prevent you from running the script, you can temporarily bypass that with:
+```
+powershell -noprofile -ExecutionPolicy Bypass -file .\Renamer.ps1 -apiName My_Api
+```
+
+Or you can change your execution policy, prior to running the script, permanently with (this disables security so, be cautious):
+```
+Set-ExecutionPolicy Unrestricted
+```
+
+After the renaming is done, the script will ask you if you want to delete it as well as it's useless now. It's your choice.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -25,22 +25,22 @@ Base API is a boilerplate code for being reused for new APIs for LBH
 
 The renaming of `base-api` into `SomethingElseApi` can be done by running a Renamer powershell script. To do so:
 1. Open the powershell and navigate to this directory's root.
-2. And run the script using the following command:
+2. Run the script using the following command:
 ```
 .\Renamer.ps1 -apiName My_Api
 ```
 
-If your script execution policiy prevent you from running the script, you can temporarily bypass that with:
+If your ***script execution policy*** prevents you from running the script, you can temporarily ***bypass*** that with:
 ```
 powershell -noprofile -ExecutionPolicy Bypass -file .\Renamer.ps1 -apiName My_Api
 ```
 
-Or you can change your execution policy, prior to running the script, permanently with (this disables security so, be cautious):
+Or you can change your execution policy, prior to running the script, permanently with _(this disables security so, be cautious)_:
 ```
 Set-ExecutionPolicy Unrestricted
 ```
 
-After the renaming is done, the script will ask you if you want to delete it as well as it's useless now. It's your choice.
+After the renaming is done, the ***script will ask you if you want to delete it as well***, as it's useless now - It's your choice.
 
 ### Development
 

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -21,3 +21,16 @@ Get-ChildItem -File -Recurse -exclude *.ps1 | % {
         Write-Host $("File renamed from '{0}' to '{1}'." -f $fileName, $newName)
     }
 }
+
+Write-Host "`nScanning directories...`n"
+
+Get-ChildItem -Directory -Recurse |
+Sort-Object -Descending FullName |
+Where-Object { $_.Name -match 'base-api' } | % {
+    Write-Host $("Editing directory: '{0}'." -f $_.FullName)
+    $newDirName = $_.Name -replace 'base-api', $apiName
+    Rename-Item -Path $_.FullName -NewName $newDirName
+    Write-Host $("Directory renamed from '{0}' to '{1}'." -f $_.Name, $newDirName)
+}
+
+Write-Host "Renaming done.`n`n"

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -14,4 +14,10 @@ Get-ChildItem -File -Recurse -exclude *.ps1 | % {
         $contents -replace 'base-api', $apiName -replace 'base_api', $apiName | Set-Content $_.PSPath
         Write-Host $("'{0}': contents changed." -f $fileName)
     }
+    
+    if ($fileName -match 'base-api') {
+        $newName = $_.Name -replace 'base-api', $apiName
+        Rename-Item -Path $_.PSPath -NewName $newName
+        Write-Host $("File renamed from '{0}' to '{1}'." -f $fileName, $newName)
+    }
 }

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -4,6 +4,12 @@ param(
     [String]$apiName
 )
 
+if ($apiName -match '-') {
+    Write-Host "`nModifying Input to avoid C# namespaces naming error ('-' not allowed)."
+    Write-Host $("Changing input from '{0}' to '{1}'.`n" -f $apiName, $apiName.replace('-', '_'))
+    $apiName = $apiName.replace('-', '_')
+}
+
 Write-Host "`nScanning files...`n"
 
 Get-ChildItem -File -Recurse -exclude *.ps1 | % {

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -40,3 +40,14 @@ Where-Object { $_.Name -match 'base-api' } | % {
 }
 
 Write-Host "Renaming done.`n`n"
+
+Write-Host $("Do you want to delete Renamer script file?`nTarget filepath: '$PSCommandPath'.")
+
+do { $myInput = (Read-Host 'Delete Script? (Y/N)').ToLower() } while ($myInput -notin @('y', 'n'))
+if ($myInput -eq 'y') {
+    Remove-Item -Force $PSCommandPath
+    Write-Host "Script file was deleted."
+}
+else {
+    Write-Host "Keeping the script file."
+}

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [String]$apiName
+)
+
+Write-Host "`nScanning files...`n"
+
+Get-ChildItem -File -Recurse -exclude *.ps1 | % {
+    $contents = (Get-Content $_.PSPath)
+    $fileName = $_.Name
+
+    if ($contents -match "base-api" -or $contents -match "base_api") {
+        $contents -replace 'base-api', $apiName -replace 'base_api', $apiName | Set-Content $_.PSPath
+        Write-Host $("'{0}': contents changed." -f $fileName)
+    }
+}

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -12,7 +12,7 @@ if ($apiName -match '-') {
 
 Write-Host "`nScanning files...`n"
 
-Get-ChildItem -File -Recurse -exclude *.ps1 | % {
+Get-ChildItem -Path $PSScriptRoot -File -Recurse -exclude *.ps1 | % {
     $contents = (Get-Content $_.PSPath)
     $fileName = $_.Name
 
@@ -30,7 +30,7 @@ Get-ChildItem -File -Recurse -exclude *.ps1 | % {
 
 Write-Host "`nScanning directories...`n"
 
-Get-ChildItem -Directory -Recurse |
+Get-ChildItem -Path $PSScriptRoot -Directory -Recurse |
 Sort-Object -Descending FullName |
 Where-Object { $_.Name -match 'base-api' } | % {
     Write-Host $("Editing directory: '{0}'." -f $_.FullName)


### PR DESCRIPTION
# What:
- A powershell script that renames the files, folders, namespaces and other things within files from the template name of `base-api` and `base_api` to whatever user inputs.
- A Readme.md description telling how to use the script.

# Why:
- The renaming of the template _(even with the 'find and replace')_ can sometimes take more than half an hour. This script was written to trim that time down to seconds because it's tedious, boring and focus-intensive task.
- Powershell script because most of the dev team is using Windows as their platform of choice. Also it's the easier script to start from _(compared to shell)_.

# Notes:
- After the renaming is done script asks the user if the user wants to delete it.
- New API name must not contain '-'. If it does, script changes that to '_' because C# namespaces fall apart, when they have that symbol in their name.
- If the `-apiName` argument is not provided when running the script, the script will ask the user to input that piece of information anyway, so no worries there.
- It says that 'tests are failing' - it's because the 'base-api' pipeline can not authenticate to aws. I'm not sure though why there's a need to connect to AWS before even running the tests 🤔 
- Requested everyone's review so that I could bring attention to that this exists now!