### PR TITLE
Fix broken build in pipeline error

### DIFF
--- a/base-api.Tests/Dockerfile
+++ b/base-api.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/base-api.Tests/base-api.Tests.csproj
+++ b/base-api.Tests/base-api.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/base-api/Dockerfile
+++ b/base-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 WORKDIR /app
 

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The project files had recently been upgraded to use .NETcore 3.1

The build stage in the pipeline was erroring with this message:
"The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 2.2 or lower, or use a version of the .NET SDK that supports .NET Core 3.1."

To fix the above error:
- This commit edits the dockerfile to use dotnet/core/sdk:3.1
- This also upgrades the versions of Npgsql.EntityFrameworkCore.PostgreSQL to 3.1.3