### PR TITLE
Add fxcop nuget package to test project to run during CI and locally

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -120,3 +120,7 @@ csharp_space_between_square_brackets = false
 #Using directives
 csharp_using_directive_placement = outside_namespace
 
+#Declaring which error categories we want the build to fail on
+# dotnet_diagnostic.CA1707.severity = error
+# dotnet_diagnostic.CA1822.severity = error
+dotnet_analyzer_diagnostic.severity = none

--- a/base-api.Tests/base-api.Tests.csproj
+++ b/base-api.Tests/base-api.Tests.csproj
@@ -4,13 +4,9 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/base-api.Tests/base-api.Tests.csproj
+++ b/base-api.Tests/base-api.Tests.csproj
@@ -4,9 +4,13 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -6,9 +6,8 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
-        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
         <RunCodeAnalysis>true</RunCodeAnalysis>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
   <ItemGroup>

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -6,12 +6,16 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <RunCodeAnalysis>true</RunCodeAnalysis>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />


### PR DESCRIPTION
We have a build-and-test job and FxCop does it's code analysis when the project is being built.
Want to take advantage of this job and see if we can get it to fail if there are errors from FxCop.

Adds the NuGet package and project properties tag to cause the production build to fail if there are any warnings from FxCop.

Next steps:
- Add config for specific errors to raise.

Any feedback and/or suggestions would be appreciated.