### PR TITLE
Add static code analysis to ci pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -120,7 +120,5 @@ csharp_space_between_square_brackets = false
 #Using directives
 csharp_using_directive_placement = outside_namespace
 
-#Declaring which error categories we want the build to fail on
+#Example: declaring which error categories we want the build to fail on.
 # dotnet_diagnostic.CA1707.severity = error
-# dotnet_diagnostic.CA1822.severity = error
-dotnet_analyzer_diagnostic.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -120,5 +120,9 @@ csharp_space_between_square_brackets = false
 #Using directives
 csharp_using_directive_placement = outside_namespace
 
-#Example: declaring which error categories we want the build to fail on.
-# dotnet_diagnostic.CA1707.severity = error
+#Suppressed FxCop Errors
+dotnet_diagnostic.CA1032.severity = none
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.CA1303.severity = none
+# Suppressed[CA1001] as not sure how to fix disposable fields within tests
+dotnet_diagnostic.CA1001.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -120,3 +120,7 @@ csharp_space_between_square_brackets = false
 #Using directives
 csharp_using_directive_placement = outside_namespace
 
+#Declaring which error categories we want the build to fail on
+# dotnet_diagnostic.CA1707.severity = error
+# dotnet_diagnostic.CA1822.severity = error
+dotnet_analyzer_diagnostic.severity = none

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ FxCop runs code analysis when the Solution is built.
 
 Both the API and Test projects have been set up to **treat all warnings from the code analysis as errors** and therefore, fail the build.
 
-However, we can select which errors to suppress by setting the severity of the responsible rule to none, e.g `dotnet_analyzer_diagnostic.<Category-or-RuleId>.severity = none`, within the `.editorConfig` file.
+However, we can select which errors to suppress by setting the severity of the responsible rule to none, e.g `dotnet_analyzer_diagnostic.<Category-or-RuleId>.severity = none`, within the `.editorconfig` file.
 Documentation on how to do this can be found [here](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019).
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Then we have an automated six step deployment process, which runs in CircleCI.
 
 Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into  `master`  branch.
 
+## Static Code Analysis
+
+### Using [FxCop Analysers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers)
+
+FxCop runs code analysis when the Solution is built.
+
+Both the API and Test projects have been set up to **treat all warnings from the code analysis as errors** and therefore, fail the build.
+
+However, we can select which errors to suppress by setting the severity of the responsible rule to none, e.g `dotnet_analyzer_diagnostic.<Category-or-RuleId>.severity = none`, within the `.editorConfig` file.
+Documentation on how to do this can be found [here](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019).
+
 ## Testing
 
 ### Run the tests

--- a/base-api.Tests/CleanTestDb.cs
+++ b/base-api.Tests/CleanTestDb.cs
@@ -1,13 +1,14 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
-using base_api.V1.Infrastructure;
+using BaseApi.V1.Infrastructure;
 
 namespace UnitTests
 {
+    [TestFixture]
     public class DbTest
     {
-        protected DatabaseContext _databaseContext;
+        protected DatabaseContext DatabaseContext { get; set; }
 
         [OneTimeSetUp]
         public void RunBeforeAnyTests()
@@ -19,17 +20,17 @@ namespace UnitTests
 
             builder.UseNpgsql(connectionString);
 
-            _databaseContext = new DatabaseContext(builder.Options);
+            DatabaseContext = new DatabaseContext(builder.Options);
 
-            _databaseContext.Database.EnsureCreated();
+            DatabaseContext.Database.EnsureCreated();
 
-            _databaseContext.Database.BeginTransaction();
+            DatabaseContext.Database.BeginTransaction();
         }
 
         [OneTimeTearDown]
         public void RunAfterAnyTests()
         {
-            _databaseContext.Database.RollbackTransaction();
+            DatabaseContext.Database.RollbackTransaction();
         }
     }
 }

--- a/base-api.Tests/V1/Controllers/HealthCheckControllerTests.cs
+++ b/base-api.Tests/V1/Controllers/HealthCheckControllerTests.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using base_api.Controllers.V1;
-using base_api.UseCase.V1;
+using BaseApi.Controllers.V1;
+using BaseApi.UseCase.V1;
 
 namespace UnitTests.V1.Controllers
 {

--- a/base-api.Tests/V1/Domain/EntityTests.cs
+++ b/base-api.Tests/V1/Domain/EntityTests.cs
@@ -1,7 +1,7 @@
 using System;
 using FluentAssertions;
 using NUnit.Framework;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
 namespace UnitTests.V1.Domain
 {

--- a/base-api.Tests/V1/Factories/EntityFactoryTest.cs
+++ b/base-api.Tests/V1/Factories/EntityFactoryTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using NUnit.Framework;
-using base_api.V1.Domain;
-using base_api.V1.Factory;
+using BaseApi.V1.Domain;
+using BaseApi.V1.Factory;
 
 namespace UnitTests.V1.Factories
 {

--- a/base-api.Tests/V1/Gateways/ExampleGatewayTests.cs
+++ b/base-api.Tests/V1/Gateways/ExampleGatewayTests.cs
@@ -1,24 +1,22 @@
 using AutoFixture;
-using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using UnitTests.V1.Helper;
-using base_api.V1.Domain;
-using base_api.V1.Gateways;
+using BaseApi.V1.Gateways;
+using BaseApi.V1.Domain;
 
 namespace UnitTests.V1.Gateways
 {
     [TestFixture]
     public class ExampleGatewayTests : DbTest
     {
-        private readonly Faker _faker = new Faker();
         private Fixture _fixture = new Fixture();
         private ExampleGateway _classUnderTest;
 
         [SetUp]
         public void Setup()
         {
-            _classUnderTest = new ExampleGateway(_databaseContext);
+            _classUnderTest = new ExampleGateway(DatabaseContext);
         }
 
         [Test]
@@ -28,7 +26,7 @@ namespace UnitTests.V1.Gateways
         }
 
         [Test]
-        public void GetEntityById_ReturnsEmptyArray()
+        public void GetEntityByIdReturnsEmptyArray()
         {
             var response = _classUnderTest.GetEntityById(123);
 
@@ -36,13 +34,13 @@ namespace UnitTests.V1.Gateways
         }
 
         [Test]
-        public void GetEntityById_ReturnsCorrectResponse()
+        public void GetEntityByIdReturnsCorrectResponse()
         {
             var entity = _fixture.Create<Entity>();
             var databaseEntity = DatabaseEntityHelper.CreateDatabaseEntityFrom(entity);
 
-            _databaseContext.DatabaseEntities.Add(databaseEntity);
-            _databaseContext.SaveChanges();
+            DatabaseContext.DatabaseEntities.Add(databaseEntity);
+            DatabaseContext.SaveChanges();
 
             var response = _classUnderTest.GetEntityById(databaseEntity.Id);
 

--- a/base-api.Tests/V1/Helper/DatabaseEntityHelper.cs
+++ b/base-api.Tests/V1/Helper/DatabaseEntityHelper.cs
@@ -1,5 +1,5 @@
 using AutoFixture;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
 namespace UnitTests.V1.Helper
 {

--- a/base-api.Tests/V1/Infrastructure/ExampleContextTests.cs
+++ b/base-api.Tests/V1/Infrastructure/ExampleContextTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using NUnit.Framework;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 using UnitTests.V1.Helper;
 
 namespace UnitTests.V1.Infrastructure
@@ -13,10 +13,10 @@ namespace UnitTests.V1.Infrastructure
         {
             DatabaseEntity databaseEntity = DatabaseEntityHelper.CreateDatabaseEntity();
 
-            _databaseContext.Add(databaseEntity);
-            _databaseContext.SaveChanges();
+            DatabaseContext.Add(databaseEntity);
+            DatabaseContext.SaveChanges();
 
-            var result = _databaseContext.DatabaseEntities.ToList().FirstOrDefault();
+            var result = DatabaseContext.DatabaseEntities.ToList().FirstOrDefault();
 
             Assert.AreEqual(result, databaseEntity);
         }

--- a/base-api.Tests/V1/UseCase/DbHealthCheckUseCaseTests.cs
+++ b/base-api.Tests/V1/UseCase/DbHealthCheckUseCaseTests.cs
@@ -3,7 +3,7 @@ using Bogus;
 using FluentAssertions;
 using Microsoft.Extensions.HealthChecks;
 using NUnit.Framework;
-using base_api.UseCase.V1;
+using BaseApi.UseCase.V1;
 using Moq;
 
 namespace UnitTests.V1.UseCase

--- a/base-api.Tests/V1/UseCase/ThrowOpsErrorUsecaseTests.cs
+++ b/base-api.Tests/V1/UseCase/ThrowOpsErrorUsecaseTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
-using base_api.UseCase.V1;
+using BaseApi.UseCase.V1;
 
 namespace UnitTests.V1.UseCase
 {

--- a/base-api.Tests/base-api.Tests.csproj
+++ b/base-api.Tests/base-api.Tests.csproj
@@ -4,11 +4,15 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/base-api/Program.cs
+++ b/base-api/Program.cs
@@ -2,9 +2,9 @@ using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
-namespace base_api
+namespace BaseApi
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {

--- a/base-api/Startup.cs
+++ b/base-api/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using BaseApi.V1.Gateways;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -10,9 +11,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using BaseApi.Versioning;
-using BaseApi.UseCase.V1;
-using BaseApi.V1.Boundary;
-using BaseApi.V1.Gateways;
 using BaseApi.V1.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Versioning;
@@ -126,6 +124,7 @@ namespace BaseApi
 
         private static void RegisterUseCases(IServiceCollection services)
         {
+            if (services == null) throw new ArgumentNullException(nameof(services));
             // your usecases here
         }
 

--- a/base-api/Startup.cs
+++ b/base-api/Startup.cs
@@ -9,18 +9,18 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using base_api.UseCase.V1;
-using base_api.V1.Boundary;
-using base_api.V1.Gateways;
-using base_api.V1.Infrastructure;
-using base_api.Versioning;
+using BaseApi.Versioning;
+using BaseApi.UseCase.V1;
+using BaseApi.V1.Boundary;
+using BaseApi.V1.Gateways;
+using BaseApi.V1.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Versioning;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 
-namespace base_api
+namespace BaseApi
 {
     public class Startup
     {
@@ -35,7 +35,7 @@ namespace base_api
         private const string ApiName = "Your API Name";
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        public static void ConfigureServices(IServiceCollection services)
         {
             services
                 .AddMvc()
@@ -130,7 +130,7 @@ namespace base_api
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public static void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/base-api/V1/Boundary/HealthCheckResponse.cs
+++ b/base-api/V1/Boundary/HealthCheckResponse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace base_api.V1.Boundary
+namespace BaseApi.V1.Boundary
 {
     public class HealthCheckResponse
     {
@@ -10,7 +10,7 @@ namespace base_api.V1.Boundary
             Message = message;
         }
 
-        public readonly bool Success;
-        public readonly string Message;
+        public bool Success { get; }
+        public string Message { get; }
     }
 }

--- a/base-api/V1/Controllers/BaseController.cs
+++ b/base-api/V1/Controllers/BaseController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace base_api.Controllers.V1
+namespace BaseApi.Controllers.V1
 {
     public class BaseController : Controller
     {

--- a/base-api/V1/Controllers/HealthCheckController.cs
+++ b/base-api/V1/Controllers/HealthCheckController.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
-using base_api.UseCase.V1;
+using BaseApi.UseCase.V1;
 
-namespace base_api.Controllers.V1
+namespace BaseApi.Controllers.V1
 {
     [Route("api/v1/healthcheck")]
     [ApiController]

--- a/base-api/V1/Domain/Entity.cs
+++ b/base-api/V1/Domain/Entity.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace base_api.V1.Domain
+namespace BaseApi.V1.Domain
 {
     public class Entity
     {

--- a/base-api/V1/Factories/AbstractEntityFactory.cs
+++ b/base-api/V1/Factories/AbstractEntityFactory.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
-namespace base_api.V1.Factory
+namespace BaseApi.V1.Factory
 {
     public abstract class AbstractEntityFactory
     {

--- a/base-api/V1/Factories/EntityFactory.cs
+++ b/base-api/V1/Factories/EntityFactory.cs
@@ -1,6 +1,6 @@
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
-namespace base_api.V1.Factory
+namespace BaseApi.V1.Factory
 {
     public class EntityFactory : AbstractEntityFactory
     {

--- a/base-api/V1/Gateways/ExampleGateway.cs
+++ b/base-api/V1/Gateways/ExampleGateway.cs
@@ -1,9 +1,8 @@
+using BaseApi.V1.Domain;
+using BaseApi.V1.Factory;
+using BaseApi.V1.Infrastructure;
 
-using base_api.V1.Domain;
-using base_api.V1.Factory;
-using base_api.V1.Infrastructure;
-
-namespace base_api.V1.Gateways
+namespace BaseApi.V1.Gateways
 {
     public class ExampleGateway : IExampleGateway
     {

--- a/base-api/V1/Gateways/IExampleGateway.cs
+++ b/base-api/V1/Gateways/IExampleGateway.cs
@@ -1,6 +1,6 @@
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
-namespace base_api.V1.Gateways
+namespace BaseApi.V1.Gateways
 {
     public interface IExampleGateway
     {

--- a/base-api/V1/Infrastructure/DatabaseContext.cs
+++ b/base-api/V1/Infrastructure/DatabaseContext.cs
@@ -1,8 +1,10 @@
 using Microsoft.EntityFrameworkCore;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
+using BaseApi.V1.Infrastructure;
 
-namespace base_api.V1.Infrastructure
+namespace BaseApi.V1.Infrastructure
 {
+
     public class DatabaseContext : DbContext, IDatabaseContext
     {
         public DatabaseContext(DbContextOptions options) : base(options)

--- a/base-api/V1/Infrastructure/DatabaseEntity.cs
+++ b/base-api/V1/Infrastructure/DatabaseEntity.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace base_api.V1.Domain
+namespace BaseApi.V1.Domain
 {
     [Table("example_entities")]
     public class DatabaseEntity

--- a/base-api/V1/Infrastructure/IDatabaseContext.cs
+++ b/base-api/V1/Infrastructure/IDatabaseContext.cs
@@ -1,5 +1,5 @@
-using Microsoft.EntityFrameworkCore;
 using BaseApi.V1.Domain;
+using Microsoft.EntityFrameworkCore;
 
 namespace BaseApi.V1.Infrastructure
 {

--- a/base-api/V1/Infrastructure/IDatabaseContext.cs
+++ b/base-api/V1/Infrastructure/IDatabaseContext.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
-using base_api.V1.Domain;
+using BaseApi.V1.Domain;
 
-namespace base_api.V1.Infrastructure
+namespace BaseApi.V1.Infrastructure
 {
     public interface IDatabaseContext
     {

--- a/base-api/V1/UseCase/DbHealthCheckUseCase.cs
+++ b/base-api/V1/UseCase/DbHealthCheckUseCase.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.HealthChecks;
-using base_api.V1.Boundary;
+using BaseApi.V1.Boundary;
 
-namespace base_api.UseCase.V1
+namespace BaseApi.UseCase.V1
 {
     public class DbHealthCheckUseCase
     {

--- a/base-api/V1/UseCase/TestOpsErrorException.cs
+++ b/base-api/V1/UseCase/TestOpsErrorException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace base_api.UseCase.V1
+namespace BaseApi.UseCase.V1
 {
     public class TestOpsErrorException : Exception
     {

--- a/base-api/V1/UseCase/ThrowOpsErrorUsecase.cs
+++ b/base-api/V1/UseCase/ThrowOpsErrorUsecase.cs
@@ -1,7 +1,7 @@
 
-namespace base_api.UseCase.V1
+namespace BaseApi.UseCase.V1
 {
-    public class ThrowOpsErrorUsecase
+    public static class ThrowOpsErrorUsecase
     {
         public static void Execute()
         {

--- a/base-api/Versioning/ApiVersionDescriptionExtensions.cs
+++ b/base-api/Versioning/ApiVersionDescriptionExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
-namespace base_api.Versioning
+namespace BaseApi.Versioning
 {
     public static class ApiVersionDescriptionExtensions
     {

--- a/base-api/Versioning/ApiVersionExtensions.cs
+++ b/base-api/Versioning/ApiVersionExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
-namespace base_api.Versioning
+namespace BaseApi.Versioning
 {
     public static class ApiVersionExtensions
     {

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -6,9 +6,8 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
-        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
         <RunCodeAnalysis>true</RunCodeAnalysis>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
   <ItemGroup>

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -6,8 +6,9 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
-        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <RunCodeAnalysis>true</RunCodeAnalysis>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
   <ItemGroup>

--- a/base-api/base-api.csproj
+++ b/base-api/base-api.csproj
@@ -6,12 +6,16 @@
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+        <RunCodeAnalysis>true</RunCodeAnalysis>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />


### PR DESCRIPTION
Adds the [FxCop NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers) and tags to the project's `.csproj` file to cause the production build to fail if there are any errors we want to surface from FxCop.

It currently passes as we haven't defined which errors to surface and all the warnings from FxCop are currently being suppressed.