### PR TITLE
Register test database as singleton in E2E tests 

### DIFF
--- a/BaseApi.Tests/DatabaseTests.cs
+++ b/BaseApi.Tests/DatabaseTests.cs
@@ -2,12 +2,14 @@ using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using BaseApi.V1.Infrastructure;
 using BaseApi.Tests;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace UnitTests
 {
     [TestFixture]
     public class DatabaseTests
     {
+        private IDbContextTransaction _transaction;
         protected DatabaseContext DatabaseContext { get; set; }
 
         [OneTimeSetUp]
@@ -18,13 +20,14 @@ namespace UnitTests
             DatabaseContext = new DatabaseContext(builder.Options);
 
             DatabaseContext.Database.EnsureCreated();
-            DatabaseContext.Database.BeginTransaction();
+            _transaction = DatabaseContext.Database.BeginTransaction();
         }
 
         [OneTimeTearDown]
         public void RunAfterAnyTests()
         {
-            DatabaseContext.Database.RollbackTransaction();
+            _transaction.Rollback();
+            _transaction.Dispose();
         }
     }
 }

--- a/BaseApi.Tests/IntegrationTests.cs
+++ b/BaseApi.Tests/IntegrationTests.cs
@@ -1,4 +1,6 @@
 using System.Net.Http;
+using BaseApi.V1.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using NUnit.Framework;
 
@@ -7,6 +9,7 @@ namespace BaseApi.Tests
     public class IntegrationTests<TStartup> where TStartup : class
     {
         protected HttpClient Client { get; private set; }
+        protected DatabaseContext DatabaseContext { get; private set; }
 
         private MockWebApplicationFactory<TStartup> _factory;
         private NpgsqlConnection _connection;
@@ -20,6 +23,11 @@ namespace BaseApi.Tests
             var npgsqlCommand = _connection.CreateCommand();
             npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
             npgsqlCommand.ExecuteNonQuery();
+
+            var builder = new DbContextOptionsBuilder();
+            builder.UseNpgsql(_connection);
+            DatabaseContext = new DatabaseContext(builder.Options);
+            DatabaseContext.Database.EnsureCreated();
         }
 
         [SetUp]

--- a/BaseApi.Tests/MockWebApplicationFactory.cs
+++ b/BaseApi.Tests/MockWebApplicationFactory.cs
@@ -25,8 +25,10 @@ namespace BaseApi.Tests
                 .UseStartup<Startup>();
             builder.ConfigureServices(services =>
             {
-                services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(_connection),
-                    ServiceLifetime.Singleton);
+                var dbBuilder = new DbContextOptionsBuilder();
+                dbBuilder.UseNpgsql(_connection);
+                var context = new DatabaseContext(dbBuilder.Options);
+                services.AddSingleton(context);
 
                 var serviceProvider = services.BuildServiceProvider();
                 var dbContext = serviceProvider.GetRequiredService<DatabaseContext>();


### PR DESCRIPTION
- dispose of transactions in test teardown