### PR TITLE
Added Terraform deployment per environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,17 +23,19 @@ commands:
         type: string
       aws-role-name:
         type: string
+      environment:
+        type: string
     steps:
        - run:
           command: |
-              cd ./terraform/
+              cd ./terraform/<<parameters.environment>>/
               terraform get -update=true
               terraform init
           name: get and init
        - run:
           name: apply
           command: |
-            cd ./terraform/
+            cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
   deploy-lambda:
     description: "Deploys API via Serverless"
@@ -78,18 +80,21 @@ jobs:
       - terraform-init-then-apply:
           aws-role-name: 'LBH_Circle_CI_Deployment_Role'
           aws-account: $AWS_ACCOUNT_DEVELOPMENT
+          environment: 'development'
   terraform-init-and-apply-to-staging:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
           aws-role-name: 'LBH_Circle_CI_Deployment_Role'
           aws-account: $AWS_ACCOUNT_STAGING
+          environment: 'staging'
   terraform-init-and-apply-to-production:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
           aws-role-name: 'LBH_Circle_CI_Deployment_Role'
           aws-account: $AWS_ACCOUNT_PRODUCTION
+          environment: 'production'
   assume-role-development:
      executor: docker-python
      steps:

--- a/BaseApi/terraform/development/main.tf
+++ b/BaseApi/terraform/development/main.tf
@@ -1,0 +1,62 @@
+# INSTRUCTIONS: 
+# 1) ENSURE YOU POPULATE THE LOCALS 
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
+# 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
+# 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
+# 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
+# 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
+
+provider "aws" {
+  region  = "eu-west-2"
+  version = "~> 2.0"
+}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+locals {
+  application_name = your application name # The name to use for your application
+   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+}
+
+
+data "aws_iam_role" "ec2_container_service_role" {
+  name = "ecsServiceRole"
+}
+
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+terraform {
+  backend "s3" {
+    bucket  = "terraform-state-development-apis"
+    encrypt = true
+    region  = "eu-west-2"
+    key     = services/YOUR API NAME/state #e.g. "services/transactions-api/state"
+  }
+}
+
+module "development" {
+  # Delete as appropriate:
+  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/fargate"
+  # source = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/ec2"
+  cluster_name                = "development-apis"
+  ecr_name                    = ecr repository name # Replace with your repository name - pattern: "hackney/YOUR APP NAME"
+  environment_name            = "development"
+  application_name            = local.application_name 
+  security_group_name         = back end security group name # Replace with your security group name, WITHOUT SPECIFYING environment. Usually the SG has the name of your API
+  vpc_name                    = "vpc-development-apis"
+  host_port                   = port # Replace with the port to use for your api / app
+  port                        = port # Replace with the port to use for your api / app
+  desired_number_of_ec2_nodes = number of nodes # Variable will only be used if EC2 is required. Do not remove it. 
+  lb_prefix                   = "nlb-development-apis"
+  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
+  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
+  task_definition_environment_variables = {
+    ASPNETCORE_ENVIRONMENT = "development"
+  }
+  task_definition_environment_variable_count = number # This number needs to reflect the number of environment variables provided
+  cost_code = your project's cost code
+  task_definition_secrets      = {}
+  task_definition_secret_count = number # This number needs to reflect the number of environment variables provided
+}

--- a/BaseApi/terraform/production/main.tf
+++ b/BaseApi/terraform/production/main.tf
@@ -29,7 +29,7 @@ data "aws_iam_role" "ecs_task_execution_role" {
 
 terraform {
   backend "s3" {
-    bucket  = your bucket name #"terraform-state-development-apis" for development, "terraform-state-staging-apis" or "terraform-state-production-apis"
+    bucket  = "terraform-state-production-apis"
     encrypt = true
     region  = "eu-west-2"
     key     = services/YOUR API NAME/state #e.g. "services/transactions-api/state"
@@ -40,20 +40,20 @@ module "development" {
   # Delete as appropriate:
   source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/fargate"
   # source = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/ec2"
-  cluster_name                = ecs cluster name # Replace with your cluster name. For APIs: development-apis or staging-apis or production-apis
+  cluster_name                = "production-apis"
   ecr_name                    = ecr repository name # Replace with your repository name - pattern: "hackney/YOUR APP NAME"
-  environment_name            = "development"
+  environment_name            = "production"
   application_name            = local.application_name 
   security_group_name         = back end security group name # Replace with your security group name, WITHOUT SPECIFYING environment. Usually the SG has the name of your API
-  vpc_name                    = your vpc name # The name of the VPC, without environment - vpc-development-apis or vpc-staging-apis or vpc-production-apis
+  vpc_name                    = "vpc-production-apis"
   host_port                   = port # Replace with the port to use for your api / app
   port                        = port # Replace with the port to use for your api / app
   desired_number_of_ec2_nodes = number of nodes # Variable will only be used if EC2 is required. Do not remove it. 
-  lb_prefix                   = NLB name # Replace with the existing NLB name, without environment. "nlb-development-apis" or "nlb-staging-apis" or "nlb-production-apis"
+  lb_prefix                   = "nlb-production-apis"
   ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
   lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
   task_definition_environment_variables = {
-    ASPNETCORE_ENVIRONMENT = "development"
+    ASPNETCORE_ENVIRONMENT = "production"
   }
   task_definition_environment_variable_count = number # This number needs to reflect the number of environment variables provided
   cost_code = your project's cost code

--- a/BaseApi/terraform/staging/main.tf
+++ b/BaseApi/terraform/staging/main.tf
@@ -1,0 +1,62 @@
+# INSTRUCTIONS: 
+# 1) ENSURE YOU POPULATE THE LOCALS 
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
+# 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
+# 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
+# 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
+# 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
+
+provider "aws" {
+  region  = "eu-west-2"
+  version = "~> 2.0"
+}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+locals {
+  application_name = your application name # The name to use for your application
+   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+}
+
+
+data "aws_iam_role" "ec2_container_service_role" {
+  name = "ecsServiceRole"
+}
+
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+terraform {
+  backend "s3" {
+    bucket  = "terraform-state-staging-apis"
+    encrypt = true
+    region  = "eu-west-2"
+    key     = services/YOUR API NAME/state #e.g. "services/transactions-api/state"
+  }
+}
+
+module "development" {
+  # Delete as appropriate:
+  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/fargate"
+  # source = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/ec2"
+  cluster_name                = "staging-apis"
+  ecr_name                    = ecr repository name # Replace with your repository name - pattern: "hackney/YOUR APP NAME"
+  environment_name            = "staging"
+  application_name            = local.application_name 
+  security_group_name         = back end security group name # Replace with your security group name, WITHOUT SPECIFYING environment. Usually the SG has the name of your API
+  vpc_name                    = "vpc-staging-apis"
+  host_port                   = port # Replace with the port to use for your api / app
+  port                        = port # Replace with the port to use for your api / app
+  desired_number_of_ec2_nodes = number of nodes # Variable will only be used if EC2 is required. Do not remove it. 
+  lb_prefix                   = "nlb-staging-apis"
+  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
+  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
+  task_definition_environment_variables = {
+    ASPNETCORE_ENVIRONMENT = "staging"
+  }
+  task_definition_environment_variable_count = number # This number needs to reflect the number of environment variables provided
+  cost_code = your project's cost code
+  task_definition_secrets      = {}
+  task_definition_secret_count = number # This number needs to reflect the number of environment variables provided
+}


### PR DESCRIPTION
- Added separate folders for the main.tf based on which environment they are being deployed. This is required as environments are actually separate AWS accounts and their state files live in different locations.
- Amended the pipeline to take environment as a input parameter so it can locate the correct file based on environment