### PR TITLE
A couple serverless changes

### DIFF
--- a/BaseApi/serverless.yml
+++ b/BaseApi/serverless.yml
@@ -37,7 +37,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: /${self:service}/${self:provider.stage}/
-        RoleName: lambdaExecutionRole
+        RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/BaseApi/serverless.yml
+++ b/BaseApi/serverless.yml
@@ -25,7 +25,7 @@ functions:
     role: lambdaExecutionRole
     environment:
 # TODO: Create ssm variables for this API's postgres mirror then rename base-api below to match api name
-      CONNECTION_STRING: Host=${ssm:/base-api/${self:provider.stage}/postgres-hostname};Port=5002;Database=base-api-mirror;Username=${ssm:/base-api/${self:provider.stage}/postgres-username};Password=${ssm:/base-api/${self:provider.stage}/postgres-password}
+      CONNECTION_STRING: Host=${ssm:/base-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/base-api/${self:provider.stage}/postgres-port};Database=base-api-mirror;Username=${ssm:/base-api/${self:provider.stage}/postgres-username};Password=${ssm:/base-api/${self:provider.stage}/postgres-password}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
- Add port as an ssm parameter. It will be different for different stages
- the lambda execution role name needs to be unique within each account