### PR TITLE
Create a Dockerfile for the test database

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12
+
+COPY ./database/schema.sql ./docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,11 @@ services:
     links:
       - test-database
   test-database:
-    image: postgres:12
+    image: test-database
+    build:
+      context: .
+      dockerfile: database/Dockerfile
     ports:
       - 5432:5432
     env_file:
       - database.env
-    volumes:
-      - ./database:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Circle CI won't let you mount a file using volumes in docker-compose so using a Dockerfile to copy the schema.sql instead. 
