### PR TITLE
add *nix renaming script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Use Docker to run this script on Macs:
 docker run -it -v `pwd`:/app mcr.microsoft.com/powershell
 ```
 
+#### On *nix
+
+Run the renamer.sh bash script from the project root:
+```
+./rename.sh MyApiName
+```
+Ideally you should provide a script argument in PascalCase as in the example. The script will rename all instances of base api without changing the original casing.
+
 ### Development
 
 To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.

--- a/rename.sh
+++ b/rename.sh
@@ -2,7 +2,7 @@
 
 echo -e "Input: '$1'\n"
 
-SNAKE=$(echo $1 | sed "s/\([A-Z]\)/_\L\1/g;s/^_//;s/-/_/g")
+SNAKE=$(echo $1 | sed "s/\([A-Z]\)/_\L\1/g;s/^_//;s/-/_/g;s/_\+/_/g")
 KEBAB=$(echo $SNAKE | sed -r "s/_/-/g")
 PASCAL=$(echo $SNAKE | sed -r "s/(^|_)([a-z])/\U\2/g")
 

--- a/rename.sh
+++ b/rename.sh
@@ -5,10 +5,12 @@ echo -e "Input: '$1'\n"
 SNAKE=$(echo $1 | sed "s/\([A-Z]\)/_\L\1/g;s/^_//;s/-/_/g;s/_\+/_/g")
 KEBAB=$(echo $SNAKE | sed -r "s/_/-/g")
 PASCAL=$(echo $SNAKE | sed -r "s/(^|_)([a-z])/\U\2/g")
+CAMEL=$(echo $PASCAL | sed -r "s/^([A-Z])/\L\1/g")
 
 echo "Renaming all 'base_api' -> '$SNAKE'"
 echo "Renaming all 'base-api' -> '$KEBAB'"
 echo "Renaming all 'BaseApi' -> '$PASCAL'"
+echo "Renaming all 'baseApi' -> '$CAMEL'"
 
 echo -e "\nRenaming in $PWD.\n"
 read -p "Does this sound OK? " -n 1 -r
@@ -23,11 +25,14 @@ fi
 find . -type d -not -path '*/\.git/*' | sed -e "p;s/base_api/$SNAKE/" | xargs -n2 mv
 find . -type d -not -path '*/\.git/*' | sed -e "p;s/base-api/$KEBAB/" | xargs -n2 mv
 find . -type d -not -path '*/\.git/*' | sed -e "p;s/BaseApi/$PASCAL/" | xargs -n2 mv
+find . -type d -not -path '*/\.git/*' | sed -e "p;s/baseApi/$CAMEL/" | xargs -n2 mv
 # file names
 find . -type f -not -path '*/\.git/*' | sed -e "p;s/base_api/$SNAKE/" | xargs -n2 mv
 find . -type f -not -path '*/\.git/*' | sed -e "p;s/base-api/$KEBAB/" | xargs -n2 mv
 find . -type f -not -path '*/\.git/*' | sed -e "p;s/BaseApi/$PASCAL/" | xargs -n2 mv
+find . -type f -not -path '*/\.git/*' | sed -e "p;s/baseApi/$CAMEL/" | xargs -n2 mv
 # strings
 find . -type f -not -path '*/\.git/*' -exec sed -i "s/base_api/$SNAKE/g" {} \;
 find . -type f -not -path '*/\.git/*' -exec sed -i "s/base-api/$KEBAB/g" {} \;
 find . -type f -not -path '*/\.git/*' -exec sed -i "s/BaseApi/$PASCAL/g" {} \;
+find . -type f -not -path '*/\.git/*' -exec sed -i "s/baseApi/$CAMEL/g" {} \;

--- a/rename.sh
+++ b/rename.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo -e "Input: '$1'\n"
+
+SNAKE=$(echo $1 | sed "s/\([A-Z]\)/_\L\1/g;s/^_//;s/-/_/g")
+KEBAB=$(echo $SNAKE | sed -r "s/_/-/g")
+PASCAL=$(echo $SNAKE | sed -r "s/(^|_)([a-z])/\U\2/g")
+
+echo "Renaming all 'base_api' -> '$SNAKE'"
+echo "Renaming all 'base-api' -> '$KEBAB'"
+echo "Renaming all 'BaseApi' -> '$PASCAL'"
+
+echo -e "\nRenaming in $PWD.\n"
+read -p "Does this sound OK? " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+  echo "Cancelled."
+  exit 1
+fi
+
+# folder
+find . -type d -not -path '*/\.git/*' | sed -e "p;s/base_api/$SNAKE/" | xargs -n2 mv
+find . -type d -not -path '*/\.git/*' | sed -e "p;s/base-api/$KEBAB/" | xargs -n2 mv
+find . -type d -not -path '*/\.git/*' | sed -e "p;s/BaseApi/$PASCAL/" | xargs -n2 mv
+# file names
+find . -type f -not -path '*/\.git/*' | sed -e "p;s/base_api/$SNAKE/" | xargs -n2 mv
+find . -type f -not -path '*/\.git/*' | sed -e "p;s/base-api/$KEBAB/" | xargs -n2 mv
+find . -type f -not -path '*/\.git/*' | sed -e "p;s/BaseApi/$PASCAL/" | xargs -n2 mv
+# strings
+find . -type f -not -path '*/\.git/*' -exec sed -i "s/base_api/$SNAKE/g" {} \;
+find . -type f -not -path '*/\.git/*' -exec sed -i "s/base-api/$KEBAB/g" {} \;
+find . -type f -not -path '*/\.git/*' -exec sed -i "s/BaseApi/$PASCAL/g" {} \;


### PR DESCRIPTION
## Describe this PR

### *Problem*

Currently, there is only a renaming script for Windows/PowerShell. 

### *What changes have we introduced*

Added a bash script that does (I think) the same thing the PowerShell script does.
Removes the PowerShell dependency for *nix users.

### *Follow up actions after merging PR*

I have only tested this on GNU/Linux. If anyone gets a chance, please test on macOS with the BSD variants of `find`/`sed`.

### Notes:
- This PR has been in "review" for a long time, since then the base API has changed significantly. The PowerShell script is no longer good enough - it needs a lot of tweaks itself. For the same reason this script needed minor tweaks as well.
- @alex-demetriou  has made a full script, the commit history shows me (@Duslerke ) as a co-author because I rebased the branch to avoid README.md merge conflict.
- I fixed a weird behaviour on unlikely inputs with underscores and dashes, like: 'My-Api'.
- I added camelCasing as there is at least on instance within the files that needs to be replaced in that casing. (As well as because it's possible that more camelCases will creep up in the future - good to be prepared)
- I added README.md instructions on how to use the script and a short explanation of what it does. I didn't remove the OSX part from the README as I haven't tested the script on OSX, so that back-up option might still be useful to a degree provided that this script doesn't work.
- Same as Alex, I've tested this script on GNU/Linux. It works fine.