### PR TITLE
Fix naming convention in Renamer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Set-ExecutionPolicy Unrestricted
 
 After the renaming is done, the ***script will ask you if you want to delete it as well***, as it's useless now - It's your choice.
 
+#### On OSX
+
+Use Docker to run this script on Macs:
+```
+docker run -it -v `pwd`:/app mcr.microsoft.com/powershell
+```
+
 ### Development
 
 To serve the application, run it using your IDE of choice, we use Visual Studio CE and JetBrains Rider on Mac.

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -16,13 +16,13 @@ Get-ChildItem -Path $PSScriptRoot -File -Recurse -exclude *.ps1 | % {
     $contents = (Get-Content $_.PSPath)
     $fileName = $_.Name
 
-    if ($contents -match "base-api" -or $contents -match "base_api") {
-        $contents -replace 'base-api', $apiName -replace 'base_api', $apiName | Set-Content $_.PSPath
+    if ($contents -match "BaseApi") {
+        $contents -replace 'BaseApi', $apiName | Set-Content $_.PSPath
         Write-Host $("'{0}': contents changed." -f $fileName)
     }
-    
-    if ($fileName -match 'base-api') {
-        $newName = $_.Name -replace 'base-api', $apiName
+
+    if ($fileName -match 'BaseApi') {
+        $newName = $_.Name -replace 'BaseApi', $apiName
         Rename-Item -Path $_.PSPath -NewName $newName
         Write-Host $("File renamed from '{0}' to '{1}'." -f $fileName, $newName)
     }
@@ -32,9 +32,9 @@ Write-Host "`nScanning directories...`n"
 
 Get-ChildItem -Path $PSScriptRoot -Directory -Recurse |
 Sort-Object -Descending FullName |
-Where-Object { $_.Name -match 'base-api' } | % {
+Where-Object { $_.Name -match 'BaseApi' } | % {
     Write-Host $("Editing directory: '{0}'." -f $_.FullName)
-    $newDirName = $_.Name -replace 'base-api', $apiName
+    $newDirName = $_.Name -replace 'BaseApi', $apiName
     Rename-Item -Path $_.FullName -NewName $newDirName
     Write-Host $("Directory renamed from '{0}' to '{1}'." -f $_.Name, $newDirName)
 }


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

It seems that the directory structure was renamed recently, but this means the Renamer script cannot find the things that need to be renamed.

### *What changes have we introduced*

Changed the names in the Renamer script and added a line in the Readme for running the script on Macs.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
