### PR TITLE
Update Renamer script

### DIFF
--- a/BaseApi.Tests/Properties/launchSettings.json
+++ b/BaseApi.Tests/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51535/",
+      "sslPort": 44344
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "BaseApi.Tests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ The renaming of `base-api` into `SomethingElseApi` can be done by running a Rena
 1. Open the powershell and navigate to this directory's root.
 2. Run the script using the following command:
 ```
-.\Renamer.ps1 -apiName My_Api
+.\Renamer.ps1 -apiName SomethingElseApi -apiNameDashed somethingelse-api
 ```
+
+The purpose of two parameters is to replace occurences of both BaseApi and base-api as they appear in filenames, directory names, and content.
+
 
 If your ***script execution policy*** prevents you from running the script, you can temporarily ***bypass*** that with:
 ```
-powershell -noprofile -ExecutionPolicy Bypass -file .\Renamer.ps1 -apiName My_Api
+powershell -noprofile -ExecutionPolicy Bypass -file .\Renamer.ps1 -apiName SomethingElseApi -apiNameDashed somethingelse-api
 ```
 
 Or you can change your execution policy, prior to running the script, permanently with _(this disables security so, be cautious)_:

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -24,8 +24,7 @@ Get-ChildItem -Path $PSScriptRoot -File -Recurse -exclude *.ps1 | % {
     }
 
     if ($fileName -match 'BaseApi') {
-        $newName = $_.Name -replace 'BaseApi', $apiName
-		Write-Host $("Renaming File from '{0}' to '{1}'." -f $fileName, $newName)
+        $newName = $_.Name -replace 'BaseApi', $apiName		
         Rename-Item -Path $_.PSPath -NewName $newName -Force
         Write-Host $("File renamed from '{0}' to '{1}'." -f $fileName, $newName)
     }
@@ -47,8 +46,7 @@ Get-ChildItem -Path $PSScriptRoot -Directory -Recurse |
 Sort-Object -Descending FullName |
 Where-Object { $_.Name -match 'BaseApi' } | % {	
     Write-Host $("Editing directory: '{0}'." -f $_.FullName)
-    $newDirName = $_.Name -replace 'BaseApi', $apiName		
-	Write-Host $("Renaming from '{0}' to '{1}'." -f $_.Name, $newDirName)
+    $newDirName = $_.Name -replace 'BaseApi', $apiName			
     Rename-Item -Path $_.FullName -NewName $newDirName  -Force		
     Write-Host $("Directory renamed from '{0}' to '{1}'." -f $_.Name, $newDirName)
 }

--- a/Renamer.ps1
+++ b/Renamer.ps1
@@ -1,7 +1,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [String]$apiName
+    [String]$apiName,
+	[Parameter(Mandatory = $true)]
+    [String]$apiNameDashed
 )
 
 if ($apiName -match '-') {
@@ -23,19 +25,31 @@ Get-ChildItem -Path $PSScriptRoot -File -Recurse -exclude *.ps1 | % {
 
     if ($fileName -match 'BaseApi') {
         $newName = $_.Name -replace 'BaseApi', $apiName
-        Rename-Item -Path $_.PSPath -NewName $newName
+		Write-Host $("Renaming File from '{0}' to '{1}'." -f $fileName, $newName)
+        Rename-Item -Path $_.PSPath -NewName $newName -Force
         Write-Host $("File renamed from '{0}' to '{1}'." -f $fileName, $newName)
     }
+}
+
+Get-ChildItem -Path $PSScriptRoot -File -Recurse -exclude *.ps1 | % {
+    $contents = (Get-Content $_.PSPath)
+    $fileName = $_.Name
+
+    if ($contents -match "base-api") {
+        $contents -replace 'base-api', $apiNameDashed | Set-Content $_.PSPath
+        Write-Host $("'{0}': contents changed." -f $fileName)
+    }    
 }
 
 Write-Host "`nScanning directories...`n"
 
 Get-ChildItem -Path $PSScriptRoot -Directory -Recurse |
 Sort-Object -Descending FullName |
-Where-Object { $_.Name -match 'BaseApi' } | % {
+Where-Object { $_.Name -match 'BaseApi' } | % {	
     Write-Host $("Editing directory: '{0}'." -f $_.FullName)
-    $newDirName = $_.Name -replace 'BaseApi', $apiName
-    Rename-Item -Path $_.FullName -NewName $newDirName
+    $newDirName = $_.Name -replace 'BaseApi', $apiName		
+	Write-Host $("Renaming from '{0}' to '{1}'." -f $_.Name, $newDirName)
+    Rename-Item -Path $_.FullName -NewName $newDirName  -Force		
     Write-Host $("Directory renamed from '{0}' to '{1}'." -f $_.Name, $newDirName)
 }
 


### PR DESCRIPTION
by adding a new parameter and name, we can also update the -dashed- version of the API, thus saving us some manual work.

Right now it substitutes BaseApi.
With this one, we can also have substitutions for base-api.

I tested it locally, and it replaced everything as it should, aka I could no longer find an instance of either BaseApi or base-api in files or folders or content.