### PR TITLE
Remove redundant context assignment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,6 @@ workflows:
 #             branches:
 #               only: master
 #       - deploy-to-production:
-#           context: api-assume-role-housing-production-context
 #           requires:
 #             - permit-production-release
 #             - terraform-init-and-apply-to-production


### PR DESCRIPTION
## What
- Removed redundant ci context assignment.

## Why
- This is causing deployments to fail.

## Action taken
- Removed context assignment from production deploy step in config.yml