### PR TITLE
Enable Serverless safeguards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./BaseApi/
+            npm i @serverless/safeguards-plugin --save-dev
             sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
 
 jobs:

--- a/BaseApi/policies/require-authorizer.js
+++ b/BaseApi/policies/require-authorizer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = function authorizerPolicy(policy, service) {
+    let failed = false;
+    const functions = service.compiled['serverless-state.json'].service.functions;
+
+    if (!functions) {
+        policy.approve();
+        return;
+    }
+
+    Object.entries(functions).forEach(([functionName, functionConfig]) => {
+        if (!functionConfig.events) return;
+
+        functionConfig.events.forEach((eventConfig) => {
+            if (!eventConfig.http) return;
+            if (!eventConfig.http.authorizer && eventConfig.http.path!="swagger/{proxy+}") {
+                failed = true;
+                policy.fail(
+                    `Function "${functionName}" does not have an authorizer attached to it. `
+                );
+            }
+        });
+    });
+    if (!failed) {
+        policy.approve();
+    }
+};

--- a/BaseApi/serverless.yml
+++ b/BaseApi/serverless.yml
@@ -20,6 +20,9 @@ provider:
           burstLimit: 200
           rateLimit: 100
 
+plugins:
+  - '@serverless/safeguards-plugin'
+  
 package:
 # TODO: Rename zipfile in build.sh and build.cmd to match this
   artifact: ./bin/release/netcoreapp3.1/base-api.zip
@@ -37,6 +40,12 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
+          authorizer:
+            arn: ${ssm:/api-authenticator/${self:provider.stage}/arn}
+            type: request
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            managedExternally: true
           cors:
             origin: '*'
             headers:
@@ -106,6 +115,10 @@ resources:
                     - "lambda:InvokeFunction"
                   Resource: "*"
 custom:
+  safeguards:
+    - title: Require authorizer
+      safeguard: require-authorizer
+      path: ./policies
   vpc:
     development:
       subnetIds:


### PR DESCRIPTION
Enable Serverless safeguards to ensure authorizer is present on API endpoints.