### PR TITLE
👥 Add development team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @LBHSPreston
+* @LBHackney-IT/development-team


### PR DESCRIPTION
This removes the burden from @LBHSPreston to review all changes, and mirrors the shared ownership/peer-review approach we take elsewhere.

The @LBHackney-IT/development-team is already a maintainer on this repo.