### PR TITLE
Prep for master -> main rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,20 +190,20 @@ workflows:
 #           context: api-nuget-token-context
 #           filters:
 #             branches:
-#               only: master
+#               only: main
 #       - assume-role-staging:
 #           context: api-assume-role-staging-context
 #           requires:
 #               - build-and-test
 #           filters:
 #              branches:
-#                only: master
+#                only: main
 #       - terraform-init-and-apply-to-staging:
 #           requires:
 #             - assume-role-staging
 #           filters:
 #             branches:
-#               only: master
+#               only: main
 #       - deploy-to-staging:
 #          context:
 #             - api-nuget-token-context
@@ -212,7 +212,7 @@ workflows:
 #             - terraform-init-and-apply-to-staging
 #           filters:
 #             branches:
-#               only: master
+#               only: main
 #       - permit-production-terraform-release:
 #           type: approval
 #           requires:
@@ -223,20 +223,20 @@ workflows:
 #               - permit-production-terraform-release
 #           filters:
 #              branches:
-#                only: master
+#                only: main
 #       - terraform-init-and-apply-to-production:
 #           requires:
 #             - assume-role-production
 #           filters:
 #             branches:
-#               only: master
+#               only: main
 #       - permit-production-release:
 #           type: approval
 #           requires:
 #             - deploy-to-staging
 #           filters:
 #             branches:
-#               only: master
+#               only: main
 #       - deploy-to-production:
 #           context:
 #             - api-nuget-token-context
@@ -246,4 +246,4 @@ workflows:
 #             - terraform-init-and-apply-to-production
 #           filters:
 #             branches:
-#               only: master
+#               only: main

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ $ make build && make serve
 At Hackney, we have created the NuGet Package to prevent the duplication of common code when implementing our APIs. Hence our NuGet packages will store the common code that can then be used in the relevant projects. For full details on the different features implemented within our packages please read [this ReadMe](https://github.com/LBHackney-IT/lbh-core/blob/release/README.md)
 
 ##### Using the package
-For full details on how to use the package(s) within this repository please read 
+For full details on how to use the package(s) within this repository please read
 [this wiki page](https://github.com/LBHackney-IT/lbh-core/wiki/Using-the-package(s)-from-the-Hackney.Core-repository).
 
 
 ### Release process
 
-We use a pull request workflow, where changes are made on a branch and approved by one or more other maintainers before the developer can merge into `master` branch.
+We use a pull request workflow, where changes are made on a branch and approved by one or more other maintainers before the developer can merge into `main` branch.
 
 ![Circle CI Workflow Example](docs/circle_ci_workflow.png)
 
@@ -111,7 +111,7 @@ Then we have an automated six step deployment process, which runs in CircleCI.
 5. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
 6. The application is deployed to production.
 
-Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into  `master`  branch.
+Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into  `main`  branch.
 
 ### Creating A PR
 


### PR DESCRIPTION
These days convention is to use `main` as the main branch name, but this project was created a long time ago, when `master` was more common.

To bring things into alignment we can rename the branch in GitHub. This change changes CI and readme references ready for that change.

### Post-merge steps

1. Rename the branch in https://github.com/LBHackney-IT/lbh-base-api/settings:
![Screenshot 2024-12-09 at 09 28 (Brave Browser)@2x](https://github.com/user-attachments/assets/69b42a9f-493b-430d-85ad-d9c8efaed161)
